### PR TITLE
cache gemetry in index db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+.env

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ let polygon = {
     }
 }
 
+console.log(process.env)
+
 
 window.addEventListener('DOMContentLoaded', (event) => {
 
@@ -25,10 +27,10 @@ window.addEventListener('DOMContentLoaded', (event) => {
   let map3d = new TerraFirma({
     element: mapElemenat,
     feature: polygon,
-    buffer: 10,
+    buffer: 500,
     bufferUnit: 'meters',
     resolutionMultiple: 1,
-    apiToken: ""
+    apiToken: process.env.MAPBOX_API_TOKEN
   })
 
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "terrafirma",
+  "name": "@mpwassler/terrafirma",
   "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
@@ -5106,6 +5106,12 @@
         "tslib": "^1.10.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -7232,6 +7238,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "idb": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.4.tgz",
+      "integrity": "sha512-g+CRa0NLB5R+VTd8UQK/J8eEPlZk82iwekJQOYA0bFJsc7TGDKyBywNmLBUdHPUyyazV1wN8DdHhSKzEX9Z9kQ=="
     },
     "ieee754": {
       "version": "1.1.13",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   },
   "dependencies": {
     "@mapbox/tile-cover": "^3.0.2",
-    "three": "^0.113.2",
     "@turf/turf": "^5.1.6",
     "get-pixels": "^3.3.2",
-    "gsap": "^3.2.6"
+    "gsap": "^3.2.6",
+    "idb": "^5.0.4",
+    "three": "^0.113.2"
   },
   "repository": {
     "type": "git",
@@ -23,6 +24,7 @@
     "@babel/core": "^7.11.1",
     "@babel/preset-env": "^7.11.0",
     "babel-loader": "^8.1.0",
+    "dotenv": "^8.2.0",
     "html-webpack-plugin": "^4.3.0",
     "jest": "^25.5.3",
     "standard": "^14.3.1",

--- a/src/geography/linestring.js
+++ b/src/geography/linestring.js
@@ -18,7 +18,8 @@ export class Linestring extends Geography {
     return {
       tiles: tileset,
       polygons: this.project(tilePloygons),
-      center: this.toVector(this.project(center))
+      center: this.toVector(this.project(center)),
+      boundingBox
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { TileGrid } from './tiles/tile-grid'
 import { TextureBuilder } from './scene/textureBuilder'
 import { buildMaterial } from './scene/material'
 import { EventEmitter } from './events'
+import geometryCache from './scene/geometryCache'
 
 const getTileMeters = (feature) => {
   const a = feature.geometry.coordinates[0][2][0]
@@ -45,8 +46,14 @@ class TerraFirma extends EventEmitter {
     this.loader.remove()
   }
 
+  makeCacheKey (bbox) {
+    return "area:" + bbox.reduce((val, acc) => {
+      return acc + `${val}`
+    }, "")
+  }
+
   async init () {
-    console.log( window.API_TOKEN)
+
     this.feature = new Linestring(this.opts.feature)
 
     this.scene.initilaize(this.element)
@@ -55,43 +62,64 @@ class TerraFirma extends EventEmitter {
 
     const bufferUnit = this.opts.bufferUnit || 'miles'
 
-    const { tiles, polygons, center } = this.feature
+    const { tiles, polygons, center, boundingBox } = this.feature
       .bufferBy(bufferSize, bufferUnit)
       .getTiles()
 
-
+    const key = this.makeCacheKey(boundingBox.geometry.coordinates)
 
     this.scene.start()
 
     const metersPerTile = getTileMeters(polygons.features[0])
 
-    const elevationGrid = new TileGrid({ tiles, type: 'terrain' })
+    const isInCache = await geometryCache.hasVerticiesFor(key)
 
-    const textureBuilder = new TextureBuilder(elevationGrid)
 
-    const [material, pixelData] = await Promise.all([buildMaterial(tiles), textureBuilder.pixelData()])
+    if (isInCache) {
 
-    const meshConfig = {
-      tiles: tiles,
-      center: center,
-      features: polygons,
-      gridRows: elevationGrid.shape.rows,
-      gridColumns: elevationGrid.shape.columns,
-      xResolution: elevationGrid.width,
-      yResolutuin: elevationGrid.height,
-      metersPerTile,
-      pixelData,
-      material
+      const material = await buildMaterial(tiles)
+
+      this.scene.setMeshFromCache({ material, center, cacheKey: key }, (averageElevation) => {
+        this.scene.setCameraTarget({
+          x: center.x,
+          y: center.y,
+          z: averageElevation
+        })
+        this.emit('load')
+      })
+
+    } else {
+
+      const elevationGrid = new TileGrid({ tiles, type: 'terrain' })
+
+      const textureBuilder = new TextureBuilder(elevationGrid)
+
+      const [material, pixelData] = await Promise.all([buildMaterial(tiles), textureBuilder.pixelData()])
+
+      const meshConfig = {
+        tiles: tiles,
+        center: center,
+        features: polygons,
+        gridRows: elevationGrid.shape.rows,
+        gridColumns: elevationGrid.shape.columns,
+        xResolution: elevationGrid.width,
+        yResolutuin: elevationGrid.height,
+        metersPerTile,
+        pixelData,
+        material,
+        cacheKey: key
+      }
+
+      this.scene.setMesh(meshConfig, (averageElevation) => {
+        this.scene.setCameraTarget({
+          x: center.x,
+          y: center.y,
+          z: averageElevation
+        })
+        this.emit('load')
+      })
     }
 
-    this.scene.setMesh(meshConfig, (averageElevation) => {
-      this.scene.setCameraTarget({
-        x: center.x,
-        y: center.y,
-        z: averageElevation
-      })
-      this.emit('load')
-    })
   }
 
   drawLine (geojson) {

--- a/src/scene/geometry.js
+++ b/src/scene/geometry.js
@@ -3,7 +3,7 @@ import {
   BufferAttribute
 } from 'three'
 
-window.PlaneBufferGeometry = PlaneBufferGeometry
+import geometryCache from './geometryCache'
 
 const workerFunc = () => {
   importScripts("https://cdnjs.cloudflare.com/ajax/libs/three.js/r119/three.min.js")
@@ -67,7 +67,8 @@ const elevationWorker = new window.Worker(blobURL)
 
 const build = (data, onComplete) => {
   elevationWorker.postMessage(data)
-  elevationWorker.onmessage = (event) => {
+  elevationWorker.onmessage = async (event) => {
+    await geometryCache.save(data.cacheKey, event.data)
     const { vertices, meters, gridSize, widthRes, heightRes, averageElevation } = event.data
     const geometry = new PlaneBufferGeometry(
       meters * gridSize[0],

--- a/src/scene/geometryCache.js
+++ b/src/scene/geometryCache.js
@@ -1,0 +1,27 @@
+import { openDB, deleteDB, wrap, unwrap } from 'idb'
+
+const STORE_NAME = "geometry-cache"
+const DB_NAME = "map3d"
+const VERSION = 1
+
+const dbPromise = openDB(DB_NAME, VERSION, {
+  upgrade(db) {
+    db.createObjectStore(STORE_NAME)
+  },
+})
+
+export default {
+  async save(key, value) {
+    return (await dbPromise).put(STORE_NAME, value, key)
+  },
+
+  async get(key, value) {
+    return (await dbPromise).get(STORE_NAME, key)
+  },
+
+  async hasVerticiesFor (key) {
+    let cache = await dbPromise
+    let val = await cache.get(STORE_NAME, key)
+    return !!val
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
-const path = require('path');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+const webpack = require('webpack')
+var dotenv = require('dotenv').config({path: __dirname + '/.env'})
 
 module.exports = {
 entry: './index.js',
@@ -17,6 +19,9 @@ plugins: [
     new HtmlWebpackPlugin({
        filename: 'index.html',
        template: './src/index.html'
+    }),
+    new webpack.DefinePlugin({
+        "process.env": dotenv.parsed
     })
 ],
 module: {


### PR DESCRIPTION
This adds basic caching of pre computed geometry data in a local index DB database. This greatly speeds up subsequent page loads when a map is loaded multiple times. It also greatly reduces tiles loaded from mapbox. 

I may also try to export a gLTF scene file and save that in index DB to include the satellite textures as well. 

Getting the tile requests down will help a lot with the viability of this library.